### PR TITLE
fix: prevent SSTI RCE via ApplicationContext exposure in FreeMarker t…

### DIFF
--- a/publiccms-parent/publiccms-common/src/main/java/com/publiccms/common/servlet/HttpRequestHashModel.java
+++ b/publiccms-parent/publiccms-common/src/main/java/com/publiccms/common/servlet/HttpRequestHashModel.java
@@ -44,14 +44,19 @@ public final class HttpRequestHashModel implements TemplateHashModelEx {
         this.wrapper = wrapper;
     }
 
+    private static boolean isBlocked(String key) {
+        for (String prefix : BLOCKED_PREFIXES) {
+            if (key.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public TemplateModel get(String key) throws TemplateModelException {
-        if (key != null) {
-            for (String prefix : BLOCKED_PREFIXES) {
-                if (key.startsWith(prefix)) {
-                    return null;
-                }
-            }
+        if (key == null || isBlocked(key)) {
+            return null;
         }
         return wrapper.wrap(request.getAttribute(key));
     }
@@ -75,7 +80,10 @@ public final class HttpRequestHashModel implements TemplateHashModelEx {
     public TemplateCollectionModel keys() {
         List<String> keys = new ArrayList<>();
         for (Enumeration<String> enumeration = request.getAttributeNames(); enumeration.hasMoreElements();) {
-            keys.add(enumeration.nextElement());
+            String name = enumeration.nextElement();
+            if (!isBlocked(name)) {
+                keys.add(name);
+            }
         }
         return new SimpleCollection(keys.iterator(), wrapper);
     }
@@ -84,7 +92,10 @@ public final class HttpRequestHashModel implements TemplateHashModelEx {
     public TemplateCollectionModel values() {
         List<Object> values = new ArrayList<>();
         for (Enumeration<String> enumeration = request.getAttributeNames(); enumeration.hasMoreElements();) {
-            values.add(request.getAttribute(enumeration.nextElement()));
+            String name = enumeration.nextElement();
+            if (!isBlocked(name)) {
+                values.add(request.getAttribute(name));
+            }
         }
         return new SimpleCollection(values.iterator(), wrapper);
     }

--- a/publiccms-parent/publiccms-common/src/main/java/com/publiccms/common/servlet/HttpRequestHashModel.java
+++ b/publiccms-parent/publiccms-common/src/main/java/com/publiccms/common/servlet/HttpRequestHashModel.java
@@ -22,6 +22,11 @@ public final class HttpRequestHashModel implements TemplateHashModelEx {
     private final HttpServletResponse response;
     private final ObjectWrapper wrapper;
 
+    private static final String[] BLOCKED_PREFIXES = {
+            "org.springframework.web.servlet.DispatcherServlet.",
+            "org.springframework.web.context.WebApplicationContext"
+    };
+
     /**
      * @param request 
      * @param wrapper
@@ -41,6 +46,13 @@ public final class HttpRequestHashModel implements TemplateHashModelEx {
 
     @Override
     public TemplateModel get(String key) throws TemplateModelException {
+        if (key != null) {
+            for (String prefix : BLOCKED_PREFIXES) {
+                if (key.startsWith(prefix)) {
+                    return null;
+                }
+            }
+        }
         return wrapper.wrap(request.getAttribute(key));
     }
 

--- a/publiccms-parent/publiccms-core/src/main/java/com/publiccms/common/base/AbstractFreemarkerView.java
+++ b/publiccms-parent/publiccms-core/src/main/java/com/publiccms/common/base/AbstractFreemarkerView.java
@@ -64,6 +64,7 @@ public abstract class AbstractFreemarkerView extends FreeMarkerView {
             throws Exception {
         model.put(SPRING_MACRO_REQUEST_CONTEXT_ATTRIBUTE, new SafeRequestContext(request, response, getServletContext(), model));
         model.put(FreemarkerServlet.KEY_REQUEST, new HttpRequestHashModel(request, response, getObjectWrapper()));
+        model.put(FreemarkerServlet.KEY_APPLICATION, null);
         super.doRender(model, request, response);
     }
 


### PR DESCRIPTION
# Fix: Prevent SSTI RCE via ApplicationContext exposure in FreeMarker templates

## Summary

This PR fixes a **critical Server-Side Template Injection (SSTI) vulnerability** that allows authenticated admin users to bypass all existing FreeMarker security controls and achieve **Remote Code Execution (RCE)**.

## Vulnerability Details

PublicCMS implements multiple layers of SSTI protection (`allows_nothing`, `api=false`, `SafeRequestContext`, `MemberAccessPolicy`). However, the `Application` (ServletContext) variable is **not wrapped with any security control** in `AbstractFreemarkerView.doRender()`.

An attacker can exploit this by:
1. Accessing `Application["org.springframework.web.context.WebApplicationContext.ROOT"]` to obtain the Spring `ApplicationContext`
2. Getting the `templateComponent` bean and its `webConfiguration` (FreeMarker `Configuration` object)
3. Calling `setSetting("new_builtin_class_resolver", "unrestricted")` to disable `allows_nothing` at runtime
4. Using `"freemarker.template.utility.Execute"?new()("command")` to execute arbitrary system commands

Additionally, `HttpRequestHashModel.get()` directly passes through `request.getAttribute(key)` without filtering, providing a secondary attack path via `Request["org.springframework.web.servlet.DispatcherServlet.CONTEXT"]`.

## Affected Versions

All versions of PublicCMS V4.0, V5, and V6 (including latest V5.202506.d / V6.202506.d).

## Changes

### 1. `AbstractFreemarkerView.java` (1 line added)

Nullify the `Application` variable to block direct access to `ServletContext` attributes from templates:

```java
model.put(FreemarkerServlet.KEY_APPLICATION, null);
```

### 2. `HttpRequestHashModel.java` (12 lines added)

Add a blocklist filter in `get()` to prevent access to Spring internal request attributes:

```java
private static final String[] BLOCKED_PREFIXES = {
    "org.springframework.web.servlet.DispatcherServlet.",
    "org.springframework.web.context.WebApplicationContext"
};
```

## Impact on Existing Functionality

**None.** FreeMarker templates in PublicCMS do not require direct access to raw `ServletContext` attributes or Spring internal `DispatcherServlet` request attributes. All CMS directives (`@cms.content`, `@cms.category`, etc.) and built-in template variables (`site`, `domain`, `base`, etc.) remain fully functional.

## Testing

- ✅ SSTI RCE payload blocked after patch (returns empty instead of command output)
- ✅ Normal template rendering works correctly (index.html, CMS directives)
- ✅ Admin panel fully functional
- ✅ No regression in existing functionality
